### PR TITLE
Add support for Marker zIndex and tags API

### DIFF
--- a/play-services-api/src/main/aidl/com/google/android/gms/maps/model/internal/IMarkerDelegate.aidl
+++ b/play-services-api/src/main/aidl/com/google/android/gms/maps/model/internal/IMarkerDelegate.aidl
@@ -30,4 +30,8 @@ interface IMarkerDelegate {
 	void setInfoWindowAnchor(float x, float y);
 	void setAlpha(float alpha);
 	float getAlpha();
+	void setZIndex(float zIndex);
+	float getZIndex();
+	void setTag(IObjectWrapper obj);
+	IObjectWrapper getTag();
 }

--- a/play-services-api/src/main/java/com/google/android/gms/maps/model/MarkerOptions.java
+++ b/play-services-api/src/main/java/com/google/android/gms/maps/model/MarkerOptions.java
@@ -58,6 +58,8 @@ public class MarkerOptions extends AutoSafeParcelable {
     private float infoWindowAnchorV = 1F;
     @SafeParceled(14)
     private float alpha = 1F;
+    @SafeParceled(15)
+    private float zIndex = 0F;
 
     /**
      * Creates a new set of marker options.
@@ -324,6 +326,15 @@ public class MarkerOptions extends AutoSafeParcelable {
     public MarkerOptions visible(boolean visible) {
         this.visible = visible;
         return this;
+    }
+
+    public MarkerOptions zIndex(float zIndex) {
+        this.zIndex = zIndex;
+        return this;
+    }
+
+    public float getZIndex() {
+        return this.zIndex;
     }
 
     public static Creator<MarkerOptions> CREATOR = new AutoCreator<MarkerOptions>(MarkerOptions.class);


### PR DESCRIPTION
## Description
This PR adds the interface definitions for ZIndex and tags on Map markers.

See also: https://github.com/microg/android_packages_apps_GmsCore/pull/613