### PR TITLE
Add SERVICE_MISSING_PERMISSION to ConnectionResult

### DIFF
--- a/play-services-basement/src/main/java/com/google/android/gms/common/ConnectionResult.java
+++ b/play-services-basement/src/main/java/com/google/android/gms/common/ConnectionResult.java
@@ -115,6 +115,11 @@ public class ConnectionResult {
      * Using the API on the device should be avoided.
      */
     public static final int API_UNAVAILABLE = 16;
+    
+    /**
+     * Service doesn't have one or more required permissions.
+     */
+    public static final int SERVICE_MISSING_PERMISSION = 19;
 
     /**
      * The Drive API requires external storage (such as an SD card), but no external storage is


### PR DESCRIPTION
This is required to build Signal w/o GMS blobs.